### PR TITLE
Strip away new line character from nimbleVersion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ export class CLI {
 	private static _nimbleVersion: string;
 	public static get nimbleVersion(): string {
 		if (!this._nimbleVersion) {
-			this._nimbleVersion = cp.execSync('npm show @nimble-ts/core version').toString('utf8');
+			this._nimbleVersion = cp.execSync('npm show @nimble-ts/core version').toString('utf8').replace(/(\r\n|\n|\r)/gm, "");
 		}
 		return this._nimbleVersion;
 	}


### PR DESCRIPTION
This fixes the generation of projects files.
Without this, the CLI is generating wrong package.json and package-lock.json files by placing a new line after package version.